### PR TITLE
Search and acquire build tools

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,0 +1,20 @@
+cmake="
+  DeclaredVersion='3.6.0'
+  SearchPathsWindows='%programfiles(x86)%\\CMake\\bin\\cmake.exe
+                      %programfiles%\\CMake\\bin\\cmake.exe
+                      %programfiles(x86)%\\Microsoft Visual Studio\\2017\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin\\cmake.exe
+                      %programfiles(x86)%\\Microsoft Visual Studio\\2017\\Professional\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin\\cmake.exe'
+  SearchPathOSXTools='Tools/downloads/CMake/cmake-3.6.0-Darwin-x86_64/CMake.app/Contents/bin/cmake'
+  SearchPathLinuxTools='Tools/downloads/CMake/cmake-3.6.0-Linux-x86_64/bin/cmake'
+  SearchPathWindows32Tools='Tools\\downloads\\CMake\\cmake-3.6.0-win32-x86\\bin\cmake.exe'
+  SearchPathWindows64Tools='Tools\\downloads\\CMake\\cmake-3.6.0-win64-x64\\bin\cmake.exe'
+  DownloadUrl='https://cmake.org/files/v3.6/'
+  DownloadPackageNameOSX='cmake-3.6.0-Darwin-x86_64.tar.gz'
+  DownloadPackageNameLinux='cmake-3.6.0-Linux-x86_64.tar.gz'
+  DownloadPackageNameWindows32='cmake-3.6.0-win32-x86.zip'
+  DownloadPackageNameWindows64='cmake-3.6.0-win64-x64.zip'
+  ToolNotFoundError='CMake is a required tool to build this repository. But this tool was not found in the PATH. Please try one of the following options to acquire CMake version \$DeclaredVersion. Download CMake version \$DeclaredVersion from \$DownloadUrl, and make sure to add CMake to PATH. Another option to acquire CMake is to run the following script $scriptPath/acquire-tool.sh cmake'
+"
+clang="
+  DeclaredVersion='4.0'
+"

--- a/config.json
+++ b/config.json
@@ -186,6 +186,12 @@
       "values": [],
       "defaultValue": ""
     },
+    "StrictToolVersionMatchAdditionalArg": {
+      "description": "Pass additional argument to build to ensure version of each tool matches the declared version.",
+      "valueType": "passThrough",
+      "values": [],
+      "defaultValue": ""
+    },
     "Project": {
       "description": "Project where the commands are going to be applied.",
       "valueType": "passThrough",
@@ -255,6 +261,10 @@
         "stripSymbols": {
           "description": "No-op. Added so that stripSymbols can be passed to build.sh without breaking build-managed.sh.",
           "settings": { }
+        },
+        "strictToolVersionMatch": {
+            "description": "No-op. Added so that strictToolVersionMatch can be passed to build.cmd without breaking build-managed.cmd.",
+            "settings": { }
         },
         "tests": {
           "description": "Builds src and then builds and runs the tests for the given configuration.",
@@ -398,10 +408,16 @@
             "StripSymbolsAdditionalArg": "stripSymbols"
           }
         },
+        "strictToolVersionMatch": {
+          "description": "Ensures version of each tool consumed in the build matches the declared version.",
+          "settings": {
+            "StrictToolVersionMatchAdditionalArg": "strictToolVersionMatch"
+          }
+        },
         "tests": {
           "description": "No-op for build-native, included just to enable easy combination with build-managed",
           "settings": { }
-        },
+        }
       },
       "defaultValues": {
         "toolName": "terminal",

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -65,8 +65,9 @@ check_native_prereqs()
     echo "Checking pre-requisites..."
 
     # Check for CMake
-    # TODO: Remove the usage comment below -
+    # TODO: Remove the usage comment below
     #   ./build.sh -StrictToolVersionMatch -- --OverrideScriptsFolderPath "/Users/raeda/Desktop/tools-local-copy/unix"
+    # Since run.exe cannot handle native-only build arguments, OverrideScriptsFolderPath is passed as additional string argument.
     probeToolsArgs="--ToolName cmake"
 
     if [ $__StrictToolVersionMatch -eq 1 ]; then

--- a/tools-local/unix/acquire-tool.sh
+++ b/tools-local/unix/acquire-tool.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Downloads the declared version of the specified tool.
+
+usage()
+{
+    echo "Usage: $0 ToolName"
+    echo "  ToolName: Name of the tool to download."
+    echo ""
+    echo "Downloads the declared version of the specified tool from the corresponding URL specified in the .toolversions file."
+    echo "If download succeeds then, returns the path to the executable."
+    echo "Exit 1 if download fails."
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "Argument passed as ToolName is empty. Please provide a non-empty string."
+    exit 1
+fi
+
+toolName="$1"
+scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+. "$scriptPath/tool-helper.sh"
+declaredVersion="$(get_tool_config_value "$toolName" "DeclaredVersion")"
+
+
+# Downloads the package corresponding to the tool, and extracts the package.
+download_extract()
+{
+    # Get the download URL
+    downloadUrl="$(get_tool_config_value "$toolName" "DownloadUrl")"
+
+    if [ $? -ne 0 ]; then
+        echo "$downloadUrl"
+        exit 1
+    fi
+
+    downloadPackageName=$(get_download_package_name "$toolName")
+
+    if [ $? -ne 0 ]; then
+        echo "$downloadPackageName"
+        exit 1
+    fi
+
+    downloadUrl="$downloadUrl$downloadPackageName"
+
+    # Create folder to save the downloaded package, and extract the package contents.
+    repoTools=$(get_repository_tools_downloads_folder "$toolName")
+    toolFolder="$repoTools/$toolName"
+    rm -rf "$toolFolder"
+    mkdir -p "$toolFolder"
+    downloadPackagePath="$toolFolder/$downloadPackageName"
+    log_message "Attempting to download $toolName from $downloadUrl to $downloadPackagePath"
+
+    # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+    which curl > /dev/null 2> /dev/null
+
+    # TODO: Use log_message to write to log file.
+    probeLog="$scriptPath/probe-tool.log"
+
+    if [ $? -ne 0 ]; then
+        wget --tries=10 -v -O "$downloadPackagePath" "$downloadUrl" 2>> "$probeLog"
+    else
+        curl --retry 10 -ssl -v -o "$downloadPackagePath" "$downloadUrl" 2>> "$probeLog"
+    fi
+
+    log_message "Attempting to extract $downloadPackagePath to $toolFolder"
+    tar -xvzf "$downloadPackagePath" -C "$toolFolder" 2>> "$probeLog"
+}
+
+# Validates if the tool is available at toolPath, and the version of the tool is the declared version.
+validate_toolpath()
+{
+    toolPath="$(get_repository_tool_search_path "$toolName")"
+    toolVersion="$("$scriptPath/invoke-extension.sh" "get-version.sh" "$toolName" --ToolPath "$toolPath")"
+
+    if [ "$toolVersion" != "$declaredVersion" ]; then
+        echo "Unable to acquire $toolName"
+        exit 1
+    fi
+
+    echo "$toolPath"
+    log_message "$toolName is available at $toolPath. Version is $toolVersion"
+}
+
+
+# Download and extract the tool.
+download_extract
+
+# Validate the download.
+validate_toolpath

--- a/tools-local/unix/cmake/get-version.sh
+++ b/tools-local/unix/cmake/get-version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Gets the version of CMake at the specified path.
+
+usage()
+{
+    echo "Usage: $0 cmake ToolName --ToolPath <path>"
+    echo "  ToolPath: Path to CMake executable or the folder containing the executable."
+    echo "If successful then, returns the version number of CMake executable."
+    echo "Exit 1 if the executable is not available at the specified path or folder."
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    exit 1
+fi
+
+toolName="$1"
+shift
+
+if [ -z "$toolName" ] || [ "$toolName" != "cmake" ]; then
+    echo "First argument should be cmake."
+    exit 1
+fi
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        --toolpath)
+            shift
+
+            if [ ! -f "$1" ]; then
+                        echo "Argument passed as ToolPath is not accessible or does not exist. Please provide a valid path."
+                        exit 1
+            fi
+
+            toolPath="$1"
+            ;;
+    esac
+    shift
+done
+
+
+# Extract version number. For example, 3.6.0 in text below.
+#cmake version 3.6.0
+#
+#CMake suite maintained and supported by Kitware (kitware.com/cmake).
+
+# Assumed that one or more digits followed by a decimal point is the start of version number. Get all text till end of line.
+echo "$("$toolPath" -version | grep -o '[0-9]\+\..*')"

--- a/tools-local/unix/invoke-extension.sh
+++ b/tools-local/unix/invoke-extension.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Locates and invokes the given extension script, which does a search or acquire, with the specified arguments. 
+
+usage()
+{
+    echo "Usage: $0 ScriptName ToolName -StrictToolVersionMatch --OverrideScriptsFolderPath <path>"
+    echo "  ScriptName: Name of the search or acquire script."
+    echo "  ToolName: Name of the tool to search and/or download."
+    echo "  (Optional) -StrictToolVersionMatch: If specified then, search will ensure that the version of the tool searched is the declared version."
+    echo "                                      Otherwise, search will attempt to find a version of the tool, which may not be the declared version."
+    echo "  (Optional) -OverrideScriptsFolderPath: If specified then, search and acquire scripts from the specified folder path will be invoked."
+    echo ""
+    echo "Checks if the specified tool has its own implementation of the search or acquire script. If so, invokes the corresponding script. Otherwise, invokes the base implementation."
+    echo ""
+    echo "Example #1"
+    echo "invoke-extension.sh \"search-tool.sh\" \"cmake\" -StrictToolVersionMatch"
+    echo "  Searches for the declared version of CMake using the default search scripts located within the repository."
+    echo ""
+    echo "Example #2"
+    echo "invoke-extension.sh \"acquire-tool.sh\" \"cmake\" -StrictToolVersionMatch --OverrideScriptsFolderPath=\"/Users/dotnet/MyCustomScripts\""
+    echo "  Acquires the declared version of CMake using the acquire script located in the specified folder that is \"/Users/dotnet/MyCustomScripts\"."
+    echo ""
+}
+
+if [ $# -lt 2 ]; then
+    usage
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "Argument passed as ScriptName is empty. Please provide a non-empty string."
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    echo "Argument passed as ToolName is empty. Please provide a non-empty string."
+    exit 1
+fi
+
+
+extensionScriptName="$1"
+shift
+toolName="$1"
+shift
+strictToolVersionMatch=0
+overrideScriptsFolderPath=""
+additionalArgs=""
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -stricttoolversionmatch)
+            strictToolVersionMatch=1
+            ;;
+        --overridescriptsfolderpath)
+            shift
+
+            if [ -z "$1" ] || [ ! -d "$1" ]; then
+                echo "OverrideScriptsFolderPath argument was specified but the path provided is invalid. Path: $1"
+                usage
+                exit 1
+            fi
+
+            overrideScriptsFolderPath="$(cd "$1"; pwd -P)"
+            ;;
+        --toolpath)
+            shift
+
+            if [ -z "$1" ]; then
+                echo "ToolPath argument was specified but the path provided is empty."
+                usage
+                exit 1
+            fi
+
+            additionalArgs=$additionalArgs" --ToolPath $1"
+            ;;
+        *)
+            usage
+            exit 1
+    esac
+    shift
+done
+
+scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+. "$scriptPath/tool-helper.sh"
+
+
+# Locates the appropriate extension script in the folders specified.
+#   1. In OverrideScriptsFolderPath check if the tool overrides base implementation. 
+#       a. If yes then, invoke the override, and return.
+#       b. If no then, invoke the base implementation, and return.
+#   2. If OverrideScriptsFolderPath does not exist then, perform 1.a & 1.b in the default scripts folder.
+invoke_extension_script()
+{
+    for extensionsFolder; do
+        if [ -z "$extensionsFolder" ] || [ ! -d "$extensionsFolder" ]; then
+            # Override folder was not specified or does not exist.
+            continue
+        fi
+
+        invokeScriptPath="$extensionsFolder/$toolName/$extensionScriptName"
+
+        if [ ! -f "$invokeScriptPath" ]; then
+            # Tool does not override the base implementation.
+            invokeScriptPath="$extensionsFolder/$extensionScriptName"
+        fi
+
+        if [ ! -f "$invokeScriptPath" ]; then
+            # Unlikely case where the base implementation is also not available.
+            echo "Unable to locate $invokeScriptPath"
+            exit 1
+        fi
+
+        args="$toolName $additionalArgs"
+
+        if [ $strictToolVersionMatch -eq 1 ] ; then
+            args="$toolName -StrictToolVersionMatch $additionalArgs"
+        fi
+
+        log_message "Invoking $extensionScriptName located in $(dirname $invokeScriptPath) with the following arguments $args"
+        "$invokeScriptPath" $args
+        exit $?
+    done
+}
+
+# Invoke the appropriate extension that performs the search or acquire.
+# Search in OverrideScriptsFolderPath first and then default scripts folder, which is located within the repository.
+invoke_extension_script $overrideScriptsFolderPath $scriptPath

--- a/tools-local/unix/probe-tool.sh
+++ b/tools-local/unix/probe-tool.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Searches for the specified tool. If tool is not found then, downloads the tool.
+
+usage()
+{
+    echo ""
+    echo "Usage: $0 --ToolName <name> -StrictToolVersionMatch --OverrideScriptsFolderPath <path>"
+    echo "  ToolName: Name of the tool to search and/or download."
+    echo "  (Optional) -StrictToolVersionMatch: If specified then, search will ensure that the version of the tool searched is the declared version."
+    echo "                                      Otherwise, search will attempt to find a version of the tool, which may not be the declared version."
+    echo "  (Optional) -OverrideScriptsFolderPath: If specified then, search and acquire scripts from the specified folder path will be invoked."
+    echo ""
+    echo "Invokes an extension that calls the appropriate search and/or acquire scripts. ToolName and StrictToolVersionMatch are passed on to the extension."
+    echo ""
+    echo "Example #1"
+    echo " probe-tool.sh --ToolName \"cmake\" --StrictToolVersionMatch 0"
+    echo " Probes for CMake, not necessarily the declared version, using the default search and acquire scripts located within the repository."
+    echo ""
+    echo "Example #2"
+    echo " probe-tool.sh --ToolName \"cmake\" --StrictToolVersionMatch 1 --OverrideScriptsFolderPath \"/Users/dotnet/MyCustomScripts\""
+    echo " Probes for the declared version of CMake using the search and acquire scripts located in \"/Users/dotnet/MyCustomScripts\"."
+    echo ""
+}
+
+toolName=""
+additionalArgs=""
+scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+. "$scriptPath/tool-helper.sh"
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -\?|-h|--help)
+            usage
+            exit 1
+            ;;
+        --toolname)
+            shift
+
+            if [ -z "$1" ]; then
+                echo "ToolName argument was specified but no tool name was provided. Please specify the name of the tool."
+                usage
+                exit 1
+            fi
+
+            toolName="$1"
+            ;;
+        -stricttoolversionmatch)
+            additionalArgs=$additionalArgs" -StrictToolVersionMatch"
+            ;;
+        --overridescriptsfolderpath)
+            shift
+
+            if [ -z "$1" ] || [ ! -d "$1" ]; then
+                echo "OverrideScriptsFolderPath argument was specified but the path provided is invalid. Path: $1"
+                usage
+                exit 1
+            fi
+
+            additionalArgs=$additionalArgs" --OverrideScriptsFolderPath $(cd "$1"; pwd -P)"
+            ;;
+        *)
+            usage
+            exit 1
+    esac
+    shift
+done
+
+if [ -z "$toolName" ]; then
+    usage
+    exit 1
+fi
+
+# Search the tool.
+log_message "Begin search for $toolName"
+toolPath="$("$scriptPath/invoke-extension.sh" "search-tool.sh" "$toolName" $additionalArgs)"
+
+# If search failed then, attempt to download the tool.
+if [ $? -ne 0 ]; then
+    log_message "Begin acquire for $toolName"
+    toolPath="$("$scriptPath/invoke-extension.sh" "acquire-tool.sh" "$toolName" $additionalArgs)"
+
+    if [ $? -ne 0 ]; then
+        # Download failed too, and hence return an error message.
+        
+        echo "$(tool_not_found_message "$toolName")"
+        exit 1
+    fi
+fi
+
+echo "$toolPath"

--- a/tools-local/unix/probe-tool.sh
+++ b/tools-local/unix/probe-tool.sh
@@ -14,11 +14,11 @@ usage()
     echo "Invokes an extension that calls the appropriate search and/or acquire scripts. ToolName and StrictToolVersionMatch are passed on to the extension."
     echo ""
     echo "Example #1"
-    echo " probe-tool.sh --ToolName \"cmake\" --StrictToolVersionMatch 0"
+    echo " probe-tool.sh --ToolName \"cmake\""
     echo " Probes for CMake, not necessarily the declared version, using the default search and acquire scripts located within the repository."
     echo ""
     echo "Example #2"
-    echo " probe-tool.sh --ToolName \"cmake\" --StrictToolVersionMatch 1 --OverrideScriptsFolderPath \"/Users/dotnet/MyCustomScripts\""
+    echo " probe-tool.sh --ToolName \"cmake\" -StrictToolVersionMatch --OverrideScriptsFolderPath \"/Users/dotnet/MyCustomScripts\""
     echo " Probes for the declared version of CMake using the search and acquire scripts located in \"/Users/dotnet/MyCustomScripts\"."
     echo ""
 }

--- a/tools-local/unix/search-tool.sh
+++ b/tools-local/unix/search-tool.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Searches for the specified tool in the environment path, and the path within the repository as specified in the .toolversions file.
+
+usage()
+{
+    echo "Usage: $0 ToolName [-StrictToolVersionMatch]"
+    echo "  ToolName: Name of the tool to download."
+    echo "  (Optional) -StrictToolVersionMatch: If specified then, search will ensure that the version of the tool searched is the declared version."
+    echo "                                      Otherwise, search will attempt to find a version of the tool, which may not be the declared version."
+    echo ""
+    echo "Searches for the tool in the environment path, and the path within the repository as specified in the .toolversions file."
+    echo "If search is successful then, returns the path to the tool."
+    echo "Exit 1 if search fails to find the tool."
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "Argument passed as ToolName is empty. Please provide a non-empty string."
+    exit 1
+fi
+
+toolName="$1"
+shift
+strictToolVersionMatch=0
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -stricttoolversionmatch)
+            strictToolVersionMatch=1
+            ;;
+        *)
+            usage
+            exit 1
+    esac
+    shift
+done
+
+scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+. "$scriptPath/tool-helper.sh"
+declaredVersion="$(get_tool_config_value "$toolName" "DeclaredVersion")"
+
+
+# Displays the tool path, and exits the script.
+display_tool_path()
+{
+    echo "$toolPath"
+    log_message "$toolName is available at $toolPath. Version is $toolVersion."
+}
+
+# Searches the tool in environment path.
+search_environment()
+{
+    log_message "Searching for $toolName in environment path."
+    hash "$toolName" 2>/dev/null
+
+    if [ $? -eq 0 ]; then
+        toolPath="$(which $toolName)"
+        toolVersion="$("$scriptPath/invoke-extension.sh" "get-version.sh" "$toolName" --ToolPath "$toolPath")"
+
+        if [ $strictToolVersionMatch -eq 0 ]; then
+            # No strictToolVersionMatch. Hence, return the path found without further checks.
+            display_tool_path
+            exit
+        else
+            # If strictToolVersionMatch is required then, ensure the version in environment path is same as declared version.
+            # If version matches then, return the path.
+            if [ "$toolVersion" == "$declaredVersion" ]; then
+                # Version available in environment path is the declared version.
+                display_tool_path
+                exit
+            fi
+        fi
+
+        log_message "Version of $toolName at $toolPath is $toolVersion. This version does not match the declared version $declaredVersion."
+    fi
+}
+
+# Searches the tool within the repository.
+search_repository()
+{
+    log_message "Searching for $toolName within the repository."
+    toolPath="$(get_repository_tool_search_path "$toolName")"
+    toolVersion="$("$scriptPath/invoke-extension.sh" "get-version.sh" "$toolName" --ToolPath "$toolPath")"
+
+    if [ "$toolVersion" == "$declaredVersion" ]; then
+        # Declared version of the tool is available within the repository.
+        display_tool_path
+        exit
+    fi
+
+    echo "Unable to locate $toolName"
+    exit 1
+}
+
+
+# Search in the environment path
+search_environment
+
+# Search within the repository in the path specified in the .toolversions file.
+search_repository

--- a/tools-local/unix/tool-helper.sh
+++ b/tools-local/unix/tool-helper.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# Provides helper functions.
+
+# Gets the repository root path.
+get_repo_root()
+{
+    scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+    repoRoot="$(cd "$scriptPath/../.."; pwd -P)"
+    echo "$repoRoot"
+}
+
+# Gets name of the operating system.
+# Exit 1 if unable to get operating system name.
+get_os_name()
+{
+    osName="$(uname -s)"
+
+    if [ $? -ne 0 ] || [ -z "$osName" ]; then
+        echo "Unable to determine the name of the operating system."
+        exit 1
+    fi
+
+    if echo "$osName" | grep -iqF "Darwin"; then
+        osName="OSX"
+    else
+        osName="Linux"
+    fi
+
+    echo "$osName"
+}
+
+# Gets the path to Tools/downloads folder under repository root.
+# Exit 1 if unable to determine the path.
+get_repository_tools_downloads_folder()
+{
+    repoRoot="$(get_repo_root)"
+    toolsPath="$repoRoot/Tools/downloads"
+    
+    if [ -z "$toolsPath" ]; then
+        echo "Unable to determine repository tools path."
+        exit 1
+    fi
+
+    echo "$toolsPath"
+}
+
+# Eval .toolversions file.
+eval_tool()
+{
+    if [ -z "$1" ]; then
+        echo "Argument passed as tool name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    toolName="$1"
+    repoRoot="$(get_repo_root)"
+    . "$repoRoot/.toolversions"
+
+    # Evaluate toolName. This assigns the metadata of toolName to tools.
+    eval "tools=\$$toolName"
+
+    # Evaluate tools. Each argument here is tool specific data such as DeclaredVersion of toolName.
+    eval "$tools"
+}
+
+# Gets the value corresponding to the specified configuration from the .toolversions file.
+# Exit 1 if the value is not found or empty.
+get_tool_config_value()
+{
+    if [ -z "$1" ]; then
+        echo "Argument passed as tool name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    if [ -z "$2" ]; then
+        echo "Argument passed as configuration name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    toolName="$1"
+    configName="$2"
+    configValue="$(eval_tool "$toolName"; eval echo "\$$configName")"
+
+    if [ -z "$configValue" ]; then
+        echo "Unable to read the value corresponding to $configName from the .toolversions file."
+        exit 1
+    fi
+
+    echo "$configValue"
+}
+
+# Gets the name of the download package corresponding to the specified tool name.
+# Download package name is read from the .toolversions file.
+# Exit 1 if unable to read the name of the download package from the .toolversions file.
+get_download_package_name()
+{
+    if [ -z "$1" ]; then
+        echo "Argument passed as tool name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    toolName="$1"
+    osName="$(get_os_name)"
+    get_tool_config_value "$toolName" "DownloadPackageName$osName"
+}
+
+# Gets the search path corresponding to the specified tool name.
+# Search path is read from the .toolversions file.
+# Exit 1 if unable to read the path from the .toolversions file.
+get_repository_tool_search_path()
+{
+    if [ -z "$1" ]; then
+        echo "Argument passed as tool name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    toolName="$1"
+    repoRoot="$(get_repo_root)"
+    osName="$(get_os_name)"
+    searchPath="$(get_tool_config_value "$toolName" "SearchPath${osName}Tools")"
+
+    echo "$repoRoot/$searchPath"
+}
+
+# Gets the error message to be displayed when the specified tool is not available for the build.
+# Error message is read from the .toolversions file.
+# Exit 1 if unable to read the error message from the .toolversions file.
+tool_not_found_message()
+{
+    if [ -z "$1" ]; then
+        echo "Argument passed as tool name is empty. Please provide a non-empty string."
+        exit 1
+    fi
+
+    toolName="$1"
+    scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+
+    # Eval in a subshell to avoid conflict with existing variables.
+    (
+        eval_tool "$toolName"
+
+        if [ -z "$ToolNotFoundError" ]; then
+            echo "Unable to locate $toolName."
+            exit 1
+        fi
+
+        eval echo "$ToolNotFoundError"
+    )
+}
+
+# Write the given message(s) to probe log file.
+log_message()
+{
+    scriptPath="$(cd "$(dirname "$0")"; pwd -P)"
+    probeLog="$scriptPath/probe-tool.log"
+    echo "$*" >> "$probeLog"
+}


### PR DESCRIPTION
Summary of the changes:
1. Tools metadata is in .toolversions file located in repository root
2. Native build invokes `probe-tool` to get a build prerequisite. Build should specify the name of the required tool. Optionally build can also specify if declared version of the tool is required. `probe-tool' invokes search and acquire scripts to get the tool on behalf of the build, and returns the tool path if successful or an error message. 
3. Scripts that search and acquire a tool are in `tools-local` folder of repository root. The design of these scripts is similar to having a ISearchTool and IAcquireTool interfaces.

ISearchTool provides a base implementation of searching for the specified tool in environment path, and the search path specified in the tools metadata file. Base implementation is in `tools-local/unix/search-tool.sh`. A tool can override this implementation if it wants to follow a customized search process. This override script will go into the tool specific folder. For example, if CMake overrides the base implementation then, the override script should be in `tools-local/unix/cmake/search-tool.sh`.
ISearchTool has abstract methods that each tool has to provide an implementation. For example, `tool_not_found_message` is a function in `tools-local/unix/tool-helper.sh`. This function gets the error message to be displayed when acquiring a tool fails. The implementation of this will be in tool specific folder, for instance, at `tools-local/unix/cmake/tool_not_found_message.sh`.

IAcquireTool provides similar virtual and abstract functions for acquiring a tool.

Entry point to these scripts is `probe-tool.sh` that gets invoked by `src/Native/build-native.sh`.

For developer workflow, a tool is downloaded off of internet. Plan for official builds, is to specify a folder path that contains search and acquire scripts that operate differently. For example, in official builds we will acquire a tool from OSS Tools repo. To provide such support, `probe-tool` has an argument called `OverrideScriptsFolderPath`, which takes the path to the folder containing a customized set of search and acquire scripts. Example usage is `./build.sh -StrictToolVersionMatch -- --OverrideScriptsFolderPath "/Users/raeda/Desktop/tools-custom/unix"`

Changes only include shell scripts. Before I implement similar ones in PowerShell I request your feedback.
@MichaelSimons @dagood @dleeapho 

